### PR TITLE
Fixed bug that if thrustlock is on (no zero thrust recevied) but a

### DIFF
--- a/modules/src/commander.c
+++ b/modules/src/commander.c
@@ -31,7 +31,7 @@
 #include "configblock.h"
 #include "param.h"
 
-#define MIN_THRUST  10000
+#define MIN_THRUST  1000
 #define MAX_THRUST  60000
 
 struct CommanderCrtpValues
@@ -153,21 +153,25 @@ void commanderGetThrust(uint16_t* thrust)
   int usedSide = side;
   uint16_t rawThrust = targetVal[usedSide].thrust;
 
-  if (thrustLocked) {
-    *thrust = 0;
-  }
-  else if (rawThrust > MIN_THRUST)
+  if (thrustLocked)
   {
-    *thrust = rawThrust;
+    *thrust = 0;
   }
   else
   {
-    *thrust = 0;
-  }
+    if (rawThrust > MIN_THRUST)
+    {
+      *thrust = rawThrust;
+    }
+    else
+    {
+      *thrust = 0;
+    }
 
-  if (rawThrust > MAX_THRUST)
-  {
-    *thrust = MAX_THRUST;
+    if (rawThrust > MAX_THRUST)
+    {
+      *thrust = MAX_THRUST;
+    }
   }
 
   commanderWatchdog();


### PR DESCRIPTION
thrust greater then MAX_THRUST is recevied this will go though. Also
changed MIN_THRUST from 10000 to 1000.